### PR TITLE
Add tests for a bug which occurs when using small dictionaries

### DIFF
--- a/test/file.js
+++ b/test/file.js
@@ -17,16 +17,18 @@ describe('lzma file decode', function(){
 
 describe('lzma file encode->decode', function(){
   ['sample0', 'sample1', 'sample2', 'sample3', 'sample4'].forEach(function(f) {
-      it('encoded '+f+' should correctly decode', function() {
-          var referenceData = fs.readFileSync('test/'+f+'.ref');
-          var data = lzmajs.compressFile(referenceData);
-          // convert to buffer
-          data = new Buffer(data);
-          // round trip
-          var data2 = lzmajs.decompressFile(data);
-          // convert to buffer
-          data2 = new Buffer(data2);
-          assert.equal(referenceData.toString('hex'), data2.toString('hex'));
+      [1, 6, 9].forEach(function(compressionLevel) {
+          it('encoded '+f+' should correctly decode with compressionLevel = '+compressionLevel, function() {
+              var referenceData = fs.readFileSync('test/'+f+'.ref');
+              var data = lzmajs.compressFile(referenceData, null, compressionLevel);
+              // convert to buffer
+              data = new Buffer(data);
+              // round trip
+              var data2 = lzmajs.decompressFile(data);
+              // convert to buffer
+              data2 = new Buffer(data2);
+              assert.equal(referenceData.toString('hex'), data2.toString('hex'));
+          });
       });
   });
 });


### PR DESCRIPTION
When using dictionaries of size up to 2**16, encoding fails and produces an invalid file which cannot be successfully decoded.

This adds testing of the compression -> decompression round trip with the compression levels 1, 6 and 9.
Using compression level 1, the bug is triggered; Levels 2 to 9 seem to work fine, at least for the sample files in test/.

It seems to me that changing `d:16` to `d:17` in [lib/Util.js](https://github.com/cscott/lzma-purejs/blob/75ed915fecef42a87abd754efede2271be18c786/lib/Util.js#L153) for compression level 1 makes this work properly, but I feel reluctant to provide that as a solution without really understanding what the problem is.
